### PR TITLE
[WIP] Add script to concatenate lanes

### DIFF
--- a/gimmebio/seqs/gimmebio/seqs/cli.py
+++ b/gimmebio/seqs/gimmebio/seqs/cli.py
@@ -6,7 +6,10 @@ from sys import stderr, stdout
 from os.path import basename
 
 from .sample_management import get_sample_name_and_end
-
+from .concat_lanes import (
+    group_filenames_by_name_read_lane,
+    concatenate_grouped_filenames,
+)
 
 @click.group()
 def seqs():
@@ -76,6 +79,16 @@ def iter_paired_end_filenames(sample_names, filenames):
         if sample_names:
             out_str = f'{sample_name}\t{out_str}'
         print(out_str)
+
+
+@seqs.command('concat-lanes')
+@click.option('-d/-w', '--dryrun/--wetrun', default=True)
+@click.argument('dest_dir')
+@click.argument('filenames', nargs=-1)
+def cli_concat_lanes(dryrun, dest_dir, filenames):
+    """Concatenate filenames (or at least write commands to stdout)."""
+    grouped = group_filenames_by_name_read_lane(filenames)
+    concatenate_grouped_filenames(grouped, dryrun=dryrun, dest_dir=dest_dir)
 
 
 if __name__ == '__main__':

--- a/gimmebio/seqs/gimmebio/seqs/concat_lanes.py
+++ b/gimmebio/seqs/gimmebio/seqs/concat_lanes.py
@@ -1,5 +1,6 @@
+
 import subprocess as sp
-from sys import argv
+from sys import stdout
 
 
 def getSname(fname):
@@ -14,19 +15,28 @@ def getRead(fname):
     return int(fname.split('/')[-1].split('R')[1].split('_')[0])
 
 
-tups = {}
-for fname in argv[1:]:
-    key = (getSname(fname), getRead(fname))
-    try:
-        tups[key]
-    except KeyError:
-        tups[key] = {}
-    tups[key][getLane(fname)]  = fname
+def group_filenames_by_name_read_lane(filenames):
+    """Return a dict of dicts where outer keys are (sample_name, read)
+    and inner keys are lane numbers. Values are filenames.
+    """
+    tups = {}
+    for fname in filenames:
+        key = (getSname(fname), getRead(fname))
+        try:
+            tups[key]
+        except KeyError:
+            tups[key] = {}
+        tups[key][getLane(fname)] = fname
+    return tups
 
-for (sname, read), val in tups.items():
-    a = val[1]
-    b = val[2]
-    out = 'concat_new/{}_R{}.fq.gz'.format(sname, read)
-    cmd = 'zcat {} {} | gzip > {}'.format(a, b, out)
-    print(cmd)
-    sp.call(cmd, shell=True)
+
+def concatenate_grouped_filenames(grouped, cmd_file=stdout, dryrun=True, dest_dir='.'):
+    """Print concat commands to cmd_file. Call the commands if dryrun is False."""
+    for (sname, read), val in grouped.items():
+        keys = sorted(val.keys())
+        filenames = [val[key] for key in keys]
+        out = f'{dest_dir}/{sname}_R{read}.fq.gz'
+        cmd = f'zcat {filenames} | gzip > {out}'
+        print(cmd, file=cmd_file)
+        if not dryrun:
+            sp.call(cmd, shell=True)

--- a/gimmebio/seqs/gimmebio/seqs/concat_lanes.py
+++ b/gimmebio/seqs/gimmebio/seqs/concat_lanes.py
@@ -1,0 +1,32 @@
+import subprocess as sp
+from sys import argv
+
+
+def getSname(fname):
+    return fname.split('/')[-1].split('_L')[0]
+
+
+def getLane(fname):
+    return int(fname.split('/')[-1].split('L00')[1].split('_')[0])
+
+
+def getRead(fname):
+    return int(fname.split('/')[-1].split('R')[1].split('_')[0])
+
+
+tups = {}
+for fname in argv[1:]:
+    key = (getSname(fname), getRead(fname))
+    try:
+        tups[key]
+    except KeyError:
+        tups[key] = {}
+    tups[key][getLane(fname)]  = fname
+
+for (sname, read), val in tups.items():
+    a = val[1]
+    b = val[2]
+    out = 'concat_new/{}_R{}.fq.gz'.format(sname, read)
+    cmd = 'zcat {} {} | gzip > {}'.format(a, b, out)
+    print(cmd)
+    sp.call(cmd, shell=True)

--- a/gimmebio/seqs/setup.py
+++ b/gimmebio/seqs/setup.py
@@ -7,7 +7,7 @@ requirements = [
 
 setup(
     name=microlib_name,
-    version='0.3.0',
+    version='0.4.0',
     author='David Danko',
     author_email='dcdanko@gmail.com',
     license='MIT license',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class InstallCmd(install):
 
 setup(
     name=PACKAGE_NAME,
-    version='0.3.0',
+    version='0.4.0',
     author='David Danko',
     author_email='dcdanko@gmail.com',
     description='Utilities and explorations in computational biology',


### PR DESCRIPTION
Add tooling to `seqs` to concatenate fastq files that are split across multiple lanes.